### PR TITLE
Layout tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
-This is the source for the [About Boston Python](https://about.bostonpython.com) site.
+# About Boston Python
 
-# Testing locally
+Content and configuration for <https://about.bostonpython.com>, built with [Jekyll](https://jekyllrb.com/) and hosted on [GitHub Pages](https://pages.github.com/).
 
-Sketchy instructions:
+## Building the site locally
+
+Prerequisites:
+
+- Ruby v2.6+ (via [rbenv](https://github.com/rbenv/rbenv), for example)
+- [Bundler](https://bundler.io/)
+
 ```
-rbenv install 2.6.2
-rbenv global 2.6.2
-gem install --user-install bundler jekyll
-export PATH=$HOME/.gem/ruby/2.6.0/bin:$PATH
+bundle install
 bundle exec jekyll serve
 ```

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,4 @@
 remote_theme: fongandrew/hydeout
 title: Boston Python
 description: The Boston-area Python user group
-
-theme: jekyll-theme-tactile
+permalink: /:categories/:title

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,9 +2,11 @@
 layout: default
 ---
 
+{% if page.title != 'Home' %}
 <header>
   <h1 class="page-title">{{ page.title }}</h1>
 </header>
+{% endif %}
 <div class="content">
   {{ content }}
 </div>

--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-title: Boston Python
+title: Home
 ---
 
 Boston Python is a large and vibrant Python user group in the Boston area.  We run [two events](events.md) most months. Anyone interested in any aspect of the Python world is welcome!

--- a/slack.md
+++ b/slack.md
@@ -1,7 +1,7 @@
 ---
 title: Slack
 sidebar_link: true
-sidebar_sort_order: 600
+sidebar_sort_order: 200
 ---
 
 Boston Python has a Slack workspace for online discussions.


### PR DESCRIPTION
The `Home`-related changes were to avoid the browser title being "Boston Python * Boston Python", and I thought the header was a little redundant.

GitHub Pages supports pretty URLs without configuration (i.e., the links below both work); this just uses them for internal links.

https://about.bostonpython.com/jobs
https://about.bostonpython.com/jobs.html