### PR TITLE
Clarify build and development instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@ Content and configuration for <https://about.bostonpython.com>, built with [Jeky
 
 ## Building the site locally
 
-Prerequisites:
-
-- Ruby v2.6+ (via [rbenv](https://github.com/rbenv/rbenv), for example)
-- [Bundler](https://bundler.io/)
-
-```
-bundle install
-bundle exec jekyll serve
-```
+-   [Clone](https://help.github.com/en/articles/cloning-a-repository) (or [fork](https://help.github.com/en/articles/about-forks) then clone) this repo.
+-   Install Ruby v2.6+ as explained in the [Jekyll docs](https://jekyllrb.com/docs/installation/) for your operating system (via [rbenv](https://github.com/rbenv/rbenv), for example).
+-   Install the Bundler and Jekyll Ruby gems:
+    -   Make sure both the installed Ruby version and RubyGems are on your path, as explained in the docs for [Jekyll](https://jekyllrb.com/docs/installation/) and [rbenv](https://github.com/rbenv/rbenv).
+    -   Run `gem install bundler jekyll`.
+-   Install the site: `cd BostonPython-about; bundle install`
+-   Serve the site: `bundle exec jekyll serve`
+-   View the site in a browser at [localhost:4000](http://localhost:4000).

--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ Content and configuration for <https://about.bostonpython.com>, built with [Jeky
 -   Install the site: `cd BostonPython-about; bundle install`
 -   Serve the site: `bundle exec jekyll serve`
 -   View the site in a browser at [localhost:4000](http://localhost:4000).
+
+## Developing the site
+
+This site uses the [Hydeout](https://fongandrew.github.io/hydeout/) theme. Most of the site's structure and style come from the theme, so please have a look at the theme source code if you're interested in making any relevant changes.


### PR DESCRIPTION

The proposed commits will clarify the build and development instructions in _README.md_. These changes may reduce install friction, making it easier for developers to contribute.

## Builds

I hadn't worked with Jekyll or Ruby in about a year, so it took me a bit of time to get on my feet again. Thankfully, the [Jekyll docs](https://jekyllrb.com/docs/) are great, so going there, and writing up a few bullet points, were all I needed to get the site up and running.

## Development

It also took me some time to figure out exactly how much the [Hydeout](https://fongandrew.github.io/hydeout/) theme was contributing to the page layouts. Once I looked up the theme source code, it made a lot more sense, so simply including a link to the source code should help developers make sense of the site.

## Checklist

- [x] I have formatted my code according to the _[.editorconfig](https://github.com/BostonPython/about/blob/master/.editorconfig)_.
- [x] I have respected the [Code of Conduct](https://about.bostonpython.com/code-of-conduct).
