### PR TITLE
Simplify global permalink

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
 remote_theme: fongandrew/hydeout
 title: Boston Python
 description: The Boston-area Python user group
-permalink: /:categories/:title
+permalink: /:name


### PR DESCRIPTION

## Simplify global permalink

There weren't any major issues with the global [permalink](https://jekyllrb.com/docs/permalinks/) setting in _\_config.yml_. Using `/:title` instead of `/:title:output_ext` avoids automatically appending the _.html_ extension.

I cleaned up the permalink a bit at least. We don't have any [categories](https://jekyllrb.com/docs/posts/#categories-and-tags) on this site, so although Jekyll will parse out `/:categories`, we don't really need it.

I also changed `/:title` to `/:name`. The `:name` refers to the filename, which is transformed into the URL slug (for example, _code-of-conduct.md_ becomes _https://about.bostonpython.com/code-of-conduct_). The `:title` will also be transformed into a slug, but we may want to set a different title for the page header (such as "Our Code of Conduct"), so `:name` is a little more useful I think.

## Attempt redirection

In the `#general` channel of [Boston Python's Slack workspace](https://slack.bostonpython.com/) on August 25, 2019, @nedbat asked about redirecting URLs with the _.html_ extension to URLs without, such as _https://about.bostonpython.com/slack.html_ redirecting to _https://about.bostonpython.com/slack_.

We don't have access to the GitHub Pages servers, so setting a `301` or `302` response is not an option.

One Jekyll option is setting `permalink: pretty` in _\_config.yml_, which will append a trailing slash and prevent URLs with _.html_ appended from being served. Rather than redirecting though, URLs with _.html_ appended just return `404`, which is a bit harsh. The URL with trailing slash actually points to _/:name/index.html_, and the URL with _index.html_ is still served.

Another option is [jekyll-redirect-from](https://github.com/jekyll/jekyll-redirect-from), which is one of the [Jekyll plugins supported by GitHub Pages](https://help.github.com/en/articles/redirects-on-github-pages), and included with the [GitHub Pages gem](https://pages.github.com/versions/). It didn't work well for this purpose. One limitation is that the redirect apparently has to be specified per-page in the YAML front matter, instead of globally in _\_config.yml_. Another limitation of jekyll-redirect-from, which is a showstopper for our purposes, is that the redirect has to refer to a completely separate page. Attempting to redirect from _/:name.html_ to _/:name_ gets the Jekyll server into a redirect loop, because they're considered the same page.

For example, activating the plugin with

```yml
# _config.yml
plugins:
  - jekyll-redirect-from
```

and setting a redirect for a page with

```yml
# slack.md
---
title: Slack
sidebar_link: true
sidebar_sort_order: 200
redirect_from: /slack.html
---

```

would just get into an infinite loop of fetching the page from the server (ramping up CPU usage), whenever attempting to navigate to either _/:name_ or _/:name.html._. The redirect loop could be stopped by navigating away from the offending page, or stopping the server entirely. Running in verbose mode with `-V` was showing repeated [servlet](https://github.com/jekyll/jekyll/blob/master/lib/jekyll/commands/serve/servlet.rb) commands:

```
[2019-08-31 21:11:40] DEBUG Jekyll::Commands::Serve::Servlet is invoked.
```

The redirect may need to refer to a _separate_ page, as seen by Jekyll. Jekyll interprets _/:name_ and _/:name.html._ to be the _same page_, so my guess is that Jekyll is repeatedly trying to redirect the page to itself.

## Checklist

- [x] I have formatted my code according to the _[.editorconfig](https://github.com/BostonPython/about/blob/master/.editorconfig)_.
- [x] I have respected the [Code of Conduct](https://about.bostonpython.com/code-of-conduct).
