### PR TITLE
Underline nav link for active page

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -33,3 +33,7 @@ h1, h2, h3, h4, h5, h6 {
     color: #666;
     font-size: 85%;
 }
+
+nav#sidebar-nav-links .active {
+    text-decoration: underline;
+}


### PR DESCRIPTION
When working with navigation menus, it's helpful to highlight the page you're on.

The [Hydeout](https://fongandrew.github.io/hydeout/) theme already underlines nav hyperlinks on hover, so adding underline for the active page goes well with the theme.

The underline required a simple change to the `.active` CSS class.

## Checklist

- [x] I have formatted my code according to the _[.editorconfig](https://github.com/BostonPython/about/blob/master/.editorconfig)_.
- [x] I have respected the [Code of Conduct](https://about.bostonpython.com/code-of-conduct).
