### PR TITLE
Update events information

### DIFF
--- a/events.md
+++ b/events.md
@@ -10,7 +10,7 @@ Boston Python runs several kinds of events, most of which are listed on the [Bos
 - **Presentation nights** feature presentations by members.  These are technical peer-to-peer presentations.  Anyone can do one!  Sometimes we do [lightning talks](lightning.md).
 - **Python Study Group nights** feature presentations by members who are beginner-to-intermediate. Each presenter chooses a topic that they're unfamiliar with, researches it, and then teaches the group what they've learned.
 - **Book Discussion nights** host discussion focused on particular books. As of March 2023, this group is currently discussing **Fluent Python (2nd ed.)** on Monday evenings. (Note: this group does **not** post events on Meetup, join us on Slack to participate!)
-- **Python en Español** presenta charlas de Python en español.
+- **Python en Español** discusión en español sobre Python.
 - **Collaboration nights** are unstructured times to sit with people with similar interests, and do whatever you would like to do.
 
 We have a [long list of past events](past-events/index.md).

--- a/events.md
+++ b/events.md
@@ -4,13 +4,13 @@ sidebar_link: true
 sidebar_sort_order: 100
 ---
 
-Boston Python runs four kinds of events:
+Boston Python runs several kinds of events, all of which are listed on the [Boston Python meetup page](http://bostonpython.com). RSVP there to be sure to get a spot.
 
-- **Presentation nights** feature presentations by members.  These are technical peer-to-peer presentations.  Anyone can do one!  Sometimes we do [lightning talks](lightning.md).
-- **Collaboration nights** are unstructured times to sit with people with similar interests, and do whatever you would like to do.
-- **Python Study Group nights** feature presentations by members who are beginner-to-intermediate. Each presenter chooses a topic that they're unfamiliar with, researches it, and then teaches the group what they've learned.
 - [**Office hour**](officehour.md) is a weekly hour to drop in and ask anything on your mind.
-
-Specific events are listed on the [Boston Python meetup page](http://bostonpython.com).  RSVP there to be sure to get a spot.
+- **Presentation nights** feature presentations by members.  These are technical peer-to-peer presentations.  Anyone can do one!  Sometimes we do [lightning talks](lightning.md).
+- **Python Study Group nights** feature presentations by members who are beginner-to-intermediate. Each presenter chooses a topic that they're unfamiliar with, researches it, and then teaches the group what they've learned.
+- **Book Discussion nights** host discussion focused on particular books. As of March 2023, this group is currently discussing **Fluent Python (2nd ed.)** on Monday evenings.
+- **Python en Español** presenta charlas de Python en español.
+- **Collaboration nights** are unstructured times to sit with people with similar interests, and do whatever you would like to do.
 
 We have a [long list of past events](past-events/index.md).

--- a/events.md
+++ b/events.md
@@ -4,12 +4,12 @@ sidebar_link: true
 sidebar_sort_order: 100
 ---
 
-Boston Python runs several kinds of events, all of which are listed on the [Boston Python meetup page](http://bostonpython.com). RSVP there to be sure to get a spot.
+Boston Python runs several kinds of events, most of which are listed on the [Boston Python meetup page](http://bostonpython.com). RSVP there to be sure to get a spot.
 
 - [**Office hour**](officehour.md) is a weekly hour to drop in and ask anything on your mind.
 - **Presentation nights** feature presentations by members.  These are technical peer-to-peer presentations.  Anyone can do one!  Sometimes we do [lightning talks](lightning.md).
 - **Python Study Group nights** feature presentations by members who are beginner-to-intermediate. Each presenter chooses a topic that they're unfamiliar with, researches it, and then teaches the group what they've learned.
-- **Book Discussion nights** host discussion focused on particular books. As of March 2023, this group is currently discussing **Fluent Python (2nd ed.)** on Monday evenings.
+- **Book Discussion nights** host discussion focused on particular books. As of March 2023, this group is currently discussing **Fluent Python (2nd ed.)** on Monday evenings. (Note: this group does **not** post events on Meetup, join us on Slack to participate!)
 - **Python en Español** presenta charlas de Python en español.
 - **Collaboration nights** are unstructured times to sit with people with similar interests, and do whatever you would like to do.
 

--- a/slack.md
+++ b/slack.md
@@ -14,6 +14,9 @@ Once you've joined, there are a number of channels, depending on what you are lo
 
 - **#general**: Questions/ideas/links of general interest to the community. When in doubt, post here.
 - **#events**: Announcements/discussion of events that might be interesting to the group.
+- **#python-en-español**: Hablar de Python y las charlas en español
+- **#study-group**: Organization and discussion of Study Group events
+- **#book-discussion**: Organization and discussion of Book Discussion events
 - **#jobs**: For job postings. They must meet our [requirements](jobs.md).
 - **#for-hire**: Where you can announce your availability for work.
 - **#organizing**: Discussion about how Boston Python works, and making it work better.


### PR DESCRIPTION
This changeset modifies the `Events` and `Slack` pages to mention our current events and their related channels