### PR TITLE
Use https to fix CC image

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -79,6 +79,6 @@ Boston Python staff will be happy to help participants contact venue security or
 
 This Code of Conduct was forked from the [PyCon US Code of Conduct](https://github.com/python/pycon-code-of-conduct/blob/master/code_of_conduct.md), which details the sources of its language.
 
-[![Creative Commons License](http://i.creativecommons.org/l/by/3.0/88x31.png)](http://creativecommons.org/licenses/by/3.0/)
+[![Creative Commons License](https://i.creativecommons.org/l/by/3.0/88x31.png)](https://creativecommons.org/licenses/by/3.0/)
 
-This Code of Conduct is licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/).
+This Code of Conduct is licensed under a [Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/).


### PR DESCRIPTION
There's a broken Creative Commons image at https://about.bostonpython.com/code-of-conduct#license

![image](https://github.com/BostonPython/about/assets/1324225/8e3a0a3b-b804-4f91-bd32-d72cead2b215)

Warnings in the console say it didn't load because of mixed HTTP and HTTPS content.

Use HTTPs versions to fix it.