### PR TITLE
Removing the {% raw %} tag seems to fix the issue locally

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -14,7 +14,8 @@ layout: default
   <p id="edit-page" class="editme">
     <strong>Have a suggestion to improve this page?</strong>
     <!-- Note: this link is wrong if testing locally, but is right on GitHub. -->
-    <br /><a href="{% raw %}{% github_edit_link %}{% endraw %}">Edit this page on GitHub</a> and submit a pull request!
+    <br />{% github_edit_link "Edit this page on GitHub" %}
+    and submit a pull request!
     <br />Or, <a href="https://github.com/BostonPython/about/issues/new">submit an issue</a> with your suggestion.
   </p>
 </footer>


### PR DESCRIPTION
See #82 

Generated link is incorrect when running locally, but per comment this seems to be expected. 